### PR TITLE
Product Management (Myrmidone) Section Empty  #9 solved

### DIFF
--- a/src/Pages/DomainDetails/DomainDetails.jsx
+++ b/src/Pages/DomainDetails/DomainDetails.jsx
@@ -48,7 +48,7 @@ const DomainDetails = () => {
       });
     }
 
-    if (id !== "uiux" && id !== "creativedesign") {
+    if (id !== "uiux" && id !== "creativedesign" && id !== "pm") {
       import(`../../data/${id}/blog.json`).then((response) => {
         setBlogs(response.blog);
       });
@@ -102,6 +102,15 @@ const DomainDetails = () => {
         import(`../../data/creativedesign/creativedesignblogs/${year}.json`).then((response) => {
           const items = response && response[year] ? response[year] : [];
           const mapped = items.map((item) => ({ author: item.title, blog: item.url }));
+          setBlogs(mapped);
+        });
+      } else if (id === "pm") {
+        import(`../../data/pm/product-management-blogs/${year}.json`).then((response) => {
+          const items = response && response[year] ? response[year] : [];
+          const mapped = items.map((item) => ({
+            author: item.author ?? item.title,
+            blog: item.blog ?? item.url,
+          }));
           setBlogs(mapped);
         });
       }

--- a/src/data/pm/2023.json
+++ b/src/data/pm/2023.json
@@ -1,0 +1,34 @@
+{
+  "2023": [
+    {
+      "title": "Jira",
+      "description": "Agile project management & sprint tracking, widely used in 2023.",
+      "url": "https://www.atlassian.com/software/jira"
+    },
+    {
+      "title": "Figma",
+      "description": "Collaborative UI/UX design and prototyping.",
+      "url": "https://www.figma.com/"
+    },
+    {
+      "title": "Hotjar",
+      "description": "Heatmaps and session recordings for user behavior insights.",
+      "url": "https://www.hotjar.com/"
+    },
+    {
+      "title": "Slack",
+      "description": "Team communication and collaboration.",
+      "url": "https://slack.com/"
+    },
+    {
+      "title": "Google Analytics",
+      "description": "Website and product analytics for tracking user behavior.",
+      "url": "https://analytics.google.com/"
+    },
+    {
+      "title": "Trello",
+      "description": "Simple Kanban boards for task management.",
+      "url": "https://trello.com/"
+    }
+  ]
+}

--- a/src/data/pm/2024.json
+++ b/src/data/pm/2024.json
@@ -1,0 +1,34 @@
+{
+  "2024": [
+      {
+        "title": "ProductPlan",
+        "description": "Visual roadmaps and prioritization, gaining popularity in 2024.",
+        "url": "https://www.productplan.com/"
+      },
+      {
+        "title": "Lookback.io",
+        "description": "Conduct user interviews and research sessions.",
+        "url": "https://lookback.io/"
+      },
+      {
+        "title": "Mixpanel",
+        "description": "Product usage tracking and funnel analysis.",
+        "url": "https://mixpanel.com/"
+      },
+      {
+        "title": "Notion",
+        "description": "Notes, documentation, and project tracking for 2024 PMs.",
+        "url": "https://www.notion.so/"
+      },
+      {
+        "title": "Miro",
+        "description": "Collaborative whiteboard for brainstorming and flowcharts.",
+        "url": "https://miro.com/"
+      },
+      {
+        "title": "InVision",
+        "description": "Interactive prototypes and design handoff.",
+        "url": "https://www.invisionapp.com/"
+      }
+    ]
+}

--- a/src/data/pm/2025.json
+++ b/src/data/pm/2025.json
@@ -1,0 +1,35 @@
+ {
+  "2025": [
+      {
+        "title": "Aha!",
+        "description": "Product roadmaps, strategy, and ideas management.",
+        "url": "https://www.aha.io/"
+      },
+      {
+        "title": "Amplitude",
+        "description": "Behavioral analytics for user retention & growth, widely adopted in 2025.",
+        "url": "https://amplitude.com/"
+      },
+      {
+        "title": "ChatGPT",
+        "description": "AI-assisted writing, brainstorming, and analysis for PMs in 2025.",
+        "url": "https://chat.openai.com/"
+      },
+      {
+        "title": "Jasper.ai",
+        "description": "AI-powered content generation and documentation help.",
+        "url": "https://www.jasper.ai/"
+      },
+      {
+        "title": "Otter.ai",
+        "description": "AI transcription for meetings and interviews.",
+        "url": "https://otter.ai/"
+      },
+      {
+        "title": "Trello AI Power-ups",
+        "description": "AI automation and prioritization for Trello boards.",
+        "url": "https://trello.com/power-ups"
+      }
+    ]
+  }
+ 

--- a/src/data/pm/blog.json
+++ b/src/data/pm/blog.json
@@ -1,40 +1,7 @@
 {
-  "blog": [
-    {
-      "blog": "https://www.appcues.com/blog",
-      "author": "AppCues Blog"
-    },
-    {
-      "blog": "https://www.productplan.com/blog/",
-      "author": "ProductPlan"
-    },
-    {
-      "blog": "https://www.lennysnewsletter.com/",
-      "author": "Lenny’s Newsletter by Lenny Rachitsky"
-    },
-    {
-      "blog": "https://www.theproductfolks.com/product-management-blog",
-      "author": "The Product Folks "
-    },
-    {
-      "blog": "https://amplitude.com/blog",
-      "author": "Amplitude Blog"
-    },
-    {
-      "blog": "https://bestpracticer.com/topic/product-management",
-      "author": "Practica"
-    },
-    {
-      "blog": "https://www.airtable.com/articles/product-management-trends",
-      "author": "Airtable"
-    },
-    {
-      "blog": "https://productschool.com/blog",
-      "author": "Product School"
-    },
-    {
-      "blog": "https://tpgblog.com/",
-      "author": "The Product Guy"
-    }
+  "years": [
+    { "year": "2023", "url": "/data/pm/product-management-blogs/2023.json" },
+    { "year": "2024", "url": "/data/pm/product-management-blogs/2024.json" },
+    { "year": "2025", "url": "/data/pm/product-management-blogs/2025.json" }
   ]
 }

--- a/src/data/pm/product-management-blogs/2023.json
+++ b/src/data/pm/product-management-blogs/2023.json
@@ -1,0 +1,29 @@
+ {
+  "2023": [
+      {
+        "blog": "https://www.productboard.com/blog/6-trends-define-product-management-2023/",
+        "author": "ProductBoard Blog"
+      },
+      {
+        "blog": "https://www.uservoice.com/blog/trends-for-2023",
+        "author": "UserVoice Blog"
+      },
+      {
+        "blog": "https://www.smartlook.com/blog/product-manager-tools/",
+        "author": "Smartlook Blog"
+      },
+      {
+        "blog": "https://lokalise.com/blog/top-product-management-blogs/",
+        "author": "Lokalise Blog"
+      },
+      {
+        "blog": "https://jocatorres.medium.com/product-management-2023-retrospective-and-2024-outlook-8b7df0cdfecb",
+        "author": "Joca Torres Medium"
+      },
+      {
+        "blog": "https://medium.com/@aakashgupta/breaking-into-product-management-in-2025-the-complete-roadmap-that-actually-works-0779ef5dc51b",
+        "author": "Aakash Gupta Medium"
+      }
+    ]
+  }
+ 

--- a/src/data/pm/product-management-blogs/2024.json
+++ b/src/data/pm/product-management-blogs/2024.json
@@ -1,0 +1,16 @@
+{
+  "2024": [
+      {
+        "blog": "https://www.theproductfolks.com/product-management-blog",
+        "author": "The Product Folks"
+      },
+      {
+        "blog": "https://thoughtbot.com/blog/a-product-manager-s-guide-to-2025",
+        "author": "Thoughtbot Blog"
+      },
+      {
+        "blog": "https://www.airtable.com/articles/product/product-management-trends",
+        "author": "Airtable Blog"
+      }
+    ]
+}

--- a/src/data/pm/product-management-blogs/2025.json
+++ b/src/data/pm/product-management-blogs/2025.json
@@ -1,0 +1,28 @@
+{
+  "2025": [
+    {
+      "blog": "https://aakashgupta.medium.com/10-trends-that-will-define-product-management-in-2025-f00b76b40271",
+      "author": "Aakash Gupta Medium"
+    },
+    {
+      "blog": "https://blog.buildbetter.ai/product-management-in-the-age-of-ai-top-trends-for-2025/",
+      "author": "BuildBetter AI Blog"
+    },
+    {
+      "blog": "https://userback.io/blog/future-of-product-management/",
+      "author": "Userback Blog"
+    },
+    {
+      "blog": "https://www.chameleon.io/blog/product-management-trends",
+      "author": "Chameleon Blog"
+    },
+    {
+      "blog": "https://arxiv.org/abs/2501.16531",
+      "author": "ArXiv"
+    },
+    {
+      "blog": "https://aakashgupta.medium.com/the-future-of-product-management-why-2025-might-be-the-perfect-time-to-enter-the-field-adfc2b5590ee",
+      "author": "Aakash Gupta Medium"
+    }
+  ]
+}

--- a/src/data/pm/years.json
+++ b/src/data/pm/years.json
@@ -1,3 +1,7 @@
 {
-  "years": []
+  "years": [
+      { "year": "2025", "url": "/data/pm/2025.json" },
+      { "year": "2024", "url": "/data/pm/2024.json" },
+      { "year": "2023", "url": "/data/pm/2023.json" }
+  ]
 }


### PR DESCRIPTION
# The issue i am solving is 
## Product Management (Myrmidone) Section Empty #9

### what i have done is 
* Added Product Management content and made sure the site links to it correctly.
* Set up yearly sections (2023/2024/2025) so users can switch years.
* Fixed data labels so items display properly on the page.
* Made “Blogs to follow” change based on the selected year for PM.
* Ensured “People to follow” images and links work.
* Confirmed the site runs locally and the build succeeds.

#### More importantly added yearbased for both tools and blogs , i dont find blogs changing with year in other sections , so i believe this can be merged , thanking you.

hosted link  to the page : 
``` bash
https://techmyrmidons-emm8yu1l1-aswins-projects-60fdcbc5.vercel.app/pm 
 ```


